### PR TITLE
hotfix(community-service): remove $schema when consuming

### DIFF
--- a/src/app/shared/services/community.service.ts
+++ b/src/app/shared/services/community.service.ts
@@ -20,13 +20,15 @@ export class CommunityService {
   }
 
   private normalizeCommunities(communities: Communities): Communities {
-    const communitiesNormalized = Object.entries(communities).map(([title, community]) => [
-      title,
-      {
-        ...community,
-        image: community.image || this.DEFAULT_IMAGE,
-      },
-    ]);
+    const communitiesNormalized = Object.entries(communities)
+      .filter(([name]) => name !== '$schema')
+      .map(([title, community]) => [
+        title,
+        {
+          ...community,
+          image: community.image || this.DEFAULT_IMAGE,
+        },
+      ]);
 
     return Object.fromEntries(communitiesNormalized);
   }


### PR DESCRIPTION
Map is broken because `$schema` is considered a community, but it isn't