### PR TITLE
fix(images): Add alternative text for images

### DIFF
--- a/src/app/pages/main/components/community-preview/community-preview.component.html
+++ b/src/app/pages/main/components/community-preview/community-preview.component.html
@@ -17,7 +17,7 @@
         *cdkVirtualFor="let community of filtered$ | async"
         (click)="onSelected(community.name)"
       >
-        <img [src]="community.image" />
+        <img alt="{{ community.name }} logo" [src]="community.image" />
         <div fxFlex="66" fxLayout="column" fxLayoutAlign="center center">
           <h3>{{ community.name }}</h3>
           <p>{{ community.city }}</p>

--- a/src/app/pages/main/components/sidenav/sidenav.component.html
+++ b/src/app/pages/main/components/sidenav/sidenav.component.html
@@ -2,7 +2,7 @@
   <mat-sidenav-content *ngIf="community; else search">
     <header>
       <span (click)="onCloseInfo()" class="link close"></span>
-      <img [src]="community.image" />
+      <img alt="{{ community.name }} logo" [src]="community.image" />
       <div fxLayout="column">
         <h1>{{ community.name }}</h1>
         <div fxLayout fxLayoutAlign="center social-links">

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar class="main-header" color="primary">
   <mat-toolbar-row class="main-header-container" fxLayout fxLayoutAlign="space-between center">
     <div fxLayout fxLayoutAlign="center center">
-      <img src="assets/images/angular.png" />
+      <img alt="Angular communities logo" src="assets/images/angular.png" />
       <span>ANGULAR COMMUNITIES</span>
     </div>
     <div>


### PR DESCRIPTION
Before this commit, Image alternative text were missing. Without alternative text,
the content of an image will not be available to screen reader users or when the image is unavailable.

After this commit, Images (community logo) will have descriptive alternative text

Closes issue #25 (https://github.com/voidcosmos/angular-communities/issues/25)